### PR TITLE
Fix interpolation default/alternate values confusion

### DIFF
--- a/src/pages/docs/env-file.mdx
+++ b/src/pages/docs/env-file.mdx
@@ -147,8 +147,8 @@ Interpolation (also known as variable expansion) is supported in environment fil
   * `${VAR:-default}` -> value of `VAR` if set and non-empty, otherwise `default`
   * `${VAR-default}` -> value of `VAR` if set, otherwise `default`
 * Alternative value
-  * `${VAR:-alternate}` -> value of `alternate` if `VAR` is set and non-empty, otherwise empty `''`
-  * `${VAR-alternate}` -> value of `alternate` if `VAR` is set and non-empty, otherwise empty `''`
+  * `${VAR:+alternate}` -> value of `alternate` if `VAR` is set and non-empty, otherwise empty `''`
+  * `${VAR+alternate}` -> value of `alternate` if `VAR` is set and non-empty, otherwise empty `''`
 
 ## Command Substitution 
 


### PR DESCRIPTION
Hello,
Here is a little PR to try and make things clear on the docs.

- [x] Fixes dotenvx/dotenvx#606 which was also occurring in this repo.

Both `default` and `alternate` interpolations were said to have the same syntax : `${VAR:-default}` and `${VAR:-alternate}`. However, they do not share such similarity. These thus achieve the same work and do not fulfill their missions.

The right syntaxes were `${VAR:-default}` and `${VAR:+alternate}`. I fixed that in the docs.
