### PR TITLE
docs: Add Node.js API convention usage documentation

### DIFF
--- a/src/pages/docs/advanced/config-convention.mdx
+++ b/src/pages/docs/advanced/config-convention.mdx
@@ -45,8 +45,9 @@ Load environment files using the dotenv-flow convention:
 
 ```sh
 # Setup environment files
-$ echo "HELLO=local" > .env.local
+$ echo "HELLO=development local" > .env.development.local
 $ echo "HELLO=development" > .env.development
+$ echo "HELLO=local" > .env.local
 $ echo "HELLO=env" > .env
 ```
 
@@ -59,8 +60,8 @@ console.log(`Hello ${process.env.HELLO}`)
 
 ```sh
 $ NODE_ENV=development node index.js
-[dotenvx@1.28.0] injecting env (1) from .env, .env.local, .env.development, .env.development.local
-Hello local
+[dotenvx@1.28.0] injecting env (1) from .env.development.local, .env.development, .env.local, .env
+Hello development local
 ```
 
 ## Flow convention with DOTENV_ENV
@@ -76,8 +77,8 @@ console.log(`Hello ${process.env.HELLO}`)
 
 ```sh
 $ DOTENV_ENV=development node index.js
-[dotenvx@1.28.0] injecting env (1) from .env, .env.local, .env.development, .env.development.local
-Hello local
+[dotenvx@1.28.0] injecting env (1) from .env.development.local, .env.development, .env.local, .env
+Hello development local
 ```
 
 ## Custom file path with convention

--- a/src/pages/docs/advanced/config-convention.mdx
+++ b/src/pages/docs/advanced/config-convention.mdx
@@ -2,7 +2,7 @@ export const description =
   'Use convention in node.js code.'
 
 ##### [Advanced](/docs/advanced)
-# dotenvx.config({ convention: 'nextjs' })
+# dotenvx.config(convention: 'nextjs')
 
 <p className="lead">{description}</p>
 
@@ -63,40 +63,3 @@ $ NODE_ENV=development node index.js
 [dotenvx@1.28.0] injecting env (1) from .env.development.local, .env.development, .env.local, .env
 Hello development local
 ```
-
-## Flow convention with DOTENV_ENV
-
-Use `DOTENV_ENV` to specify the environment:
-
-```js
-// index.js
-require('@dotenvx/dotenvx').config({ convention: 'flow' })
-
-console.log(`Hello ${process.env.HELLO}`)
-```
-
-```sh
-$ DOTENV_ENV=development node index.js
-[dotenvx@1.28.0] injecting env (1) from .env.development.local, .env.development, .env.local, .env
-Hello development local
-```
-
-## Custom file path with convention
-
-You can also combine convention with explicit path for more control:
-
-```js
-// index.js
-require('@dotenvx/dotenvx').config({
-  convention: 'nextjs',
-  path: ['.env.custom', '.env']  // Additional custom files
-})
-
-console.log(`Hello ${process.env.HELLO}`)
-```
-
-## Notes
-
-- The environment name (`NODE_ENV` or `DOTENV_ENV`) must be set before calling `config()`, typically through the command line or system environment
-- Conventions are compatible with other options like `overload`, `strict`, and encryption features
-- File loading order follows the same rules as the corresponding CLI convention

--- a/src/pages/docs/advanced/config-convention.mdx
+++ b/src/pages/docs/advanced/config-convention.mdx
@@ -1,0 +1,101 @@
+export const description =
+  'Use convention in node.js code.'
+
+##### [Advanced](/docs/advanced)
+# dotenvx.config({ convention: 'nextjs' })
+
+<p className="lead">{description}</p>
+
+Set a convention when using `dotenvx.config()`. This allows you to use the same file loading order as the CLI without needing to specify each file individually.
+
+## Next.js convention
+
+Load environment files using the Next.js convention:
+
+```sh
+# Setup environment files
+$ echo "HELLO=development local" > .env.development.local
+$ echo "HELLO=local" > .env.local
+$ echo "HELLO=development" > .env.development
+$ echo "HELLO=env" > .env
+```
+
+```js
+// index.js
+require('@dotenvx/dotenvx').config({ convention: 'nextjs' })
+
+console.log(`Hello ${process.env.HELLO}`)
+```
+
+```sh
+$ NODE_ENV=development node index.js
+[dotenvx@1.28.0] injecting env (1) from .env.development.local, .env.local, .env.development, .env
+Hello development local
+```
+
+This is equivalent to using `--convention=nextjs` with the CLI:
+
+```sh
+$ dotenvx run --convention=nextjs -- node index.js
+```
+
+## Flow convention
+
+Load environment files using the dotenv-flow convention:
+
+```sh
+# Setup environment files
+$ echo "HELLO=local" > .env.local
+$ echo "HELLO=development" > .env.development
+$ echo "HELLO=env" > .env
+```
+
+```js
+// index.js
+require('@dotenvx/dotenvx').config({ convention: 'flow' })
+
+console.log(`Hello ${process.env.HELLO}`)
+```
+
+```sh
+$ NODE_ENV=development node index.js
+[dotenvx@1.28.0] injecting env (1) from .env, .env.local, .env.development, .env.development.local
+Hello local
+```
+
+## Flow convention with DOTENV_ENV
+
+Use `DOTENV_ENV` to specify the environment:
+
+```js
+// index.js
+require('@dotenvx/dotenvx').config({ convention: 'flow' })
+
+console.log(`Hello ${process.env.HELLO}`)
+```
+
+```sh
+$ DOTENV_ENV=development node index.js
+[dotenvx@1.28.0] injecting env (1) from .env, .env.local, .env.development, .env.development.local
+Hello local
+```
+
+## Custom file path with convention
+
+You can also combine convention with explicit path for more control:
+
+```js
+// index.js
+require('@dotenvx/dotenvx').config({
+  convention: 'nextjs',
+  path: ['.env.custom', '.env']  // Additional custom files
+})
+
+console.log(`Hello ${process.env.HELLO}`)
+```
+
+## Notes
+
+- The environment name (`NODE_ENV` or `DOTENV_ENV`) must be set before calling `config()`, typically through the command line or system environment
+- Conventions are compatible with other options like `overload`, `strict`, and encryption features
+- File loading order follows the same rules as the corresponding CLI convention

--- a/src/pages/docs/advanced/index.mdx
+++ b/src/pages/docs/advanced/index.mdx
@@ -106,6 +106,7 @@ Use dotenvx directly in code.
 * [config(strict: true)](/docs/advanced/config-strict)
 * [config(ignore: ['.env.missing', '.env'])](/docs/advanced/config-ignore)
 * [config(envKeysFile: '../../.env.keys')](/docs/advanced/config-env-keys-file)
+* [config(convention: 'nextjs')](/docs/advanced/config-convention)
 * [parse(src)](/docs/advanced/parse)
 * [parse(src, \{processEnv:\})](/docs/advanced/parse-process-env)
 * [parse(src, \{privateKey:\})](/docs/advanced/parse-private-key)


### PR DESCRIPTION
## Summary
This PR adds documentation for using the `convention` option in the Node.js API, which was recently implemented in dotenvx core (see [commit c591dde](https://github.com/dotenvx/dotenvx/commit/c591dde)).

## Changes
- Added new documentation file: `src/pages/docs/advanced/config-convention.mdx`
- Documented usage examples for:
  - Next.js convention with `config({ convention: 'nextjs' })`
  - dotenv-flow convention with `config({ convention: 'flow' })`
- Added link to new documentation in `src/pages/docs/advanced/index.mdx`