### PR TITLE
Fix Heading component error under Google Translate

### DIFF
--- a/src/components/Heading.jsx
+++ b/src/components/Heading.jsx
@@ -51,7 +51,7 @@ function Anchor({ id, inView, children }) {
           </div>
         </div>
       )}
-      {children}
+      {typeof children === 'string' ? <span>{children}</span> : children}
     </Link>
   )
 }


### PR DESCRIPTION
## Overview

Fixes #31
This PR fixes a bug where an error occurred after scrolling the page when Google Translate had been applied.

## Details

The root cause lies in the Anchor component used in `src/components/Heading.tsx`.
The Anchor component toggles the visibility of the AnchorIcon during scrolling. However, Google Translate rewrites the DOM structure, which creates discrepancies between React’s virtual DOM and the actual DOM. As a result, an error was thrown when the visibility toggle was triggered.

**Before translation**
```html
<div>Text</div>
```

**After translation**
```html
<div><font>Translated Text</font></div>
```

To fix this, the PR wraps children in a <span> when they are TextNodes. This ensures that React’s element boundaries are preserved and prevents the error from occurring.
